### PR TITLE
 Referenced Java 1.8 as a possible dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Tarpit uses Maven build system. Make sure you have maven installed on your syste
 mvn clean compile package
 ```
 
+Note: Tarpit application uses sun.misc libraries which are confirmed to work with Java 1.8. In the event of build errors, please see: https://stackoverflow.com/a/52652249
+
 The `servlettarpit.war` artifact is generated in the `target` directory which can be used for further analysis.
 
 > :information_source: This packaged WAR file is intended NOT to run or be deployed in a web container. Its main goal is to be an aid for security professionals to test with [Ocular](https://ocular.shiftleft.io)


### PR DESCRIPTION
MVN build works for Java 1.8 but not OpenJDK 11, therefore I have added a note to reference Java 1.8 as a possible required version and linked this SO answer:  https://stackoverflow.com/a/52652249